### PR TITLE
Msgpack reflect-based encoding

### DIFF
--- a/entities/currency.go
+++ b/entities/currency.go
@@ -14,13 +14,13 @@ type Currency interface {
 
 // BaseCurrency is an abstract struct, do not use it directly
 type BaseCurrency struct {
-	currency Currency
-	isNative bool   // Returns whether the currency is native to the chain and must be wrapped (e.g. Ether)
-	isToken  bool   // Returns whether the currency is a token that is usable in Uniswap without wrapping
-	chainId  uint   // The chain ID on which this currency resides
-	decimals uint   // The decimals used in representing currency amounts
-	symbol   string // The symbol of the currency, i.e. a short textual non-unique identifier
-	name     string // The name of the currency, i.e. a descriptive textual non-unique identifier
+	currency Currency `msgpack:"-"`
+	isNative bool     // Returns whether the currency is native to the chain and must be wrapped (e.g. Ether)
+	isToken  bool     // Returns whether the currency is a token that is usable in Uniswap without wrapping
+	chainId  uint     // The chain ID on which this currency resides
+	decimals uint     // The decimals used in representing currency amounts
+	symbol   string   // The symbol of the currency, i.e. a short textual non-unique identifier
+	name     string   // The name of the currency, i.e. a descriptive textual non-unique identifier
 }
 
 func (c *BaseCurrency) IsNative() bool {

--- a/entities/ether.go
+++ b/entities/ether.go
@@ -32,3 +32,8 @@ func (e *Ether) Equal(other Currency) bool {
 func (e *Ether) Wrapped() *Token {
 	return WETH9[e.ChainId()]
 }
+
+func (e *Ether) AfterMsgpackUnmarshal() error {
+	e.BaseCurrency.currency = e
+	return nil
+}

--- a/entities/native.go
+++ b/entities/native.go
@@ -33,3 +33,8 @@ func (n *Native) Equal(other Currency) bool {
 func (n *Native) Wrapped() *Token {
 	return n.wrapped
 }
+
+func (n *Native) AfterMsgpackUnmarshal() error {
+	n.BaseCurrency.currency = n
+	return nil
+}

--- a/entities/token.go
+++ b/entities/token.go
@@ -73,3 +73,8 @@ func (t *Token) SortsBefore(other *Token) (bool, error) {
 func (t *Token) Wrapped() *Token {
 	return t
 }
+
+func (t *Token) AfterMsgpackUnmarshal() error {
+	t.BaseCurrency.currency = t
+	return nil
+}


### PR DESCRIPTION
added `msgpack:"-"` to BaseCurrency.currency
added AfterMsgpackUnmarshal() hook for Ether, Native, and Token structs